### PR TITLE
Better Printing and Indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
             ${{ runner.os }}-go-
       - name: Test
         run: go test ./...
+      - name: Build
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 .DS_store
 .DS_Store
+/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+# Builds Go code natively.
+build:
+	go build -buildvcs=false -o bin/ ./...

--- a/cmd/rsfprint/cmd/print.go
+++ b/cmd/rsfprint/cmd/print.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 by Posit Software, PBC
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	rsf "github.com/rstudio/repository-snapshot-format"
+	"github.com/spf13/cobra"
+)
+
+var PrintCmd = &cobra.Command{
+	Use:   "rspm",
+	Short: "Posit Package Manager",
+	Long:  "Posit Package Manager administrative toolset.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, f := range args {
+			_, err := os.Stat(f)
+			if err != nil {
+				return fmt.Errorf("unable to read %s: %s", f, err)
+			}
+		}
+
+		for _, f := range args {
+			rsfFile, err := os.Open(f)
+			if err != nil {
+				return fmt.Errorf("unable to open %s for reading: %s", f, err)
+			}
+			buf := bufio.NewReader(rsfFile)
+			err = rsf.Print(cmd.OutOrStdout(), buf)
+			if err != nil {
+				return fmt.Errorf("error printing RSF data from %s: %s", f, err)
+			}
+		}
+
+		return nil
+	},
+}

--- a/cmd/rsfprint/cmd/print_test.go
+++ b/cmd/rsfprint/cmd/print_test.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 by Posit Software, PBC
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RsfPrintCommandSuite struct {
+	suite.Suite
+}
+
+func TestRsfPrintCommandSuite(t *testing.T) {
+	suite.Run(t, &RsfPrintCommandSuite{})
+}

--- a/cmd/rsfprint/main.go
+++ b/cmd/rsfprint/main.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 by Posit Software, PBC
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/rstudio/repository-snapshot-format/cmd/rsfprint/cmd"
+)
+
+func main() {
+	log.SetOutput(os.Stdout)
+
+	cmd.PrintCmd.SetOut(os.Stdout)
+	cmd.PrintCmd.SetErr(os.Stderr)
+	err := cmd.PrintCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/rsfprint/main_test.go
+++ b/cmd/rsfprint/main_test.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 by Posit Software, PBC
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RsfPrintMainCommandSuite struct {
+	suite.Suite
+}
+
+func TestRsfPrintMainCommandSuite(t *testing.T) {
+	suite.Run(t, &RsfPrintMainCommandSuite{})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,11 @@ require github.com/stretchr/testify v1.8.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -14,6 +17,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/reader.go
+++ b/reader.go
@@ -14,7 +14,8 @@ type rsfReader struct {
 
 	// When reading an RSF file based on a struct, the first entry
 	// is an index. See `ReadIndex`.
-	index Index
+	index        Index
+	indexVersion int
 
 	// Saves the current position for advancing the reader.
 	at []string

--- a/reader_advance_test.go
+++ b/reader_advance_test.go
@@ -25,14 +25,14 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(101, r.Pos())
+	s.Assert().Equal(114, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(105, r.Pos())
+	s.Assert().Equal(118, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -41,7 +41,7 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(127, r.Pos())
 
 	// Skip the ready field and advance to "list"
 	// Array should be 100 bytes in size
@@ -52,17 +52,17 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	s.Assert().Nil(err)
 	s.Assert().Equal(100, arraySz)
 	// Position increased by 4
-	s.Assert().Equal(119, r.Pos())
+	s.Assert().Equal(132, r.Pos())
 	// Get expect array end position
 	arrayEndPos := arrayPos + arraySz
-	s.Assert().Equal(215, arrayEndPos)
+	s.Assert().Equal(228, arrayEndPos)
 
 	// Array should be 3 elements in length
 	arrayLen, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(3, arrayLen)
 	// Position increased by 4
-	s.Assert().Equal(123, r.Pos())
+	s.Assert().Equal(136, r.Pos())
 
 	// Array index. Read all three index entries
 	// Entry 1
@@ -91,8 +91,8 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// Position increased by 3(10+4) since each index entry uses
 	// a 10-byte fixed-length string and a 4-byte size field.
 	// 3*14=42
-	// 123+42=165
-	s.Assert().Equal(165, r.Pos())
+	// 136+42=178
+	s.Assert().Equal(178, r.Pos())
 
 	// Get the first array element's "Name" field
 	err = r.AdvanceTo(buf, "list", "name")
@@ -102,8 +102,8 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	s.Assert().Equal("From 2020", name)
 	// Position increased by 4+9. String size uses 4 bytes and
 	// string value uses 9 bytes.
-	// 165+13=178
-	s.Assert().Equal(178, r.Pos())
+	// 178+13=183
+	s.Assert().Equal(191, r.Pos())
 
 	// Skip the "Verified" field and advance to second array element's "Name" field
 	err = r.AdvanceToNextElement(buf)
@@ -116,8 +116,8 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// Position increased by 4+9+1. String size uses 4 bytes and
 	// string value uses 9 bytes. Also, the skipped field "verified"
 	// uses 1 byte
-	// 178+13+1=192
-	s.Assert().Equal(192, r.Pos())
+	// 191+13+1=205
+	s.Assert().Equal(205, r.Pos())
 
 	// Read the second array element's "Verified" field
 	err = r.AdvanceTo(buf, "list", "verified")
@@ -125,23 +125,23 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	verified, err := r.ReadBoolField(buf)
 	s.Assert().Nil(err)
 	s.Assert().True(verified)
-	s.Assert().Equal(193, r.Pos())
+	s.Assert().Equal(206, r.Pos())
 
 	// Skip the last array element's "Name" field and advance to "Verified".
 	// This tests skipping an array sub-element.
 	err = r.AdvanceToNextElement(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(193, r.Pos())
+	s.Assert().Equal(206, r.Pos())
 	err = r.AdvanceTo(buf, "list", "verified")
 	s.Assert().Nil(err)
 	// Last name field (skipped) read "this is from 2022"
 	// 17 bytes + 4 bytes (size) = 21
-	// 193 + 21 = 214
-	s.Assert().Equal(214, r.Pos())
+	// 206 + 21 = 227
+	s.Assert().Equal(227, r.Pos())
 	verified, err = r.ReadBoolField(buf)
 	s.Assert().Nil(err)
 	s.Assert().True(verified)
-	// 214 + 1 = 215 (arrayEndPos)
+	// 219 + 1 = 220 (arrayEndPos)
 	s.Assert().Equal(arrayEndPos, r.Pos())
 
 	// Skip age field and advance to "rating"
@@ -163,14 +163,14 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(101, r.Pos())
+	s.Assert().Equal(114, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(105, r.Pos())
+	s.Assert().Equal(118, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -179,7 +179,7 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(127, r.Pos())
 
 	// Skip the "ready" field and the "list" array and advance
 	// to "age". This tests skipping both a regular field and an entire array.
@@ -188,7 +188,7 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	age, err := r.ReadIntField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(int64(55), age)
-	s.Assert().Equal(225, r.Pos())
+	s.Assert().Equal(238, r.Pos())
 
 	// Read the "rating" field.
 	err = r.AdvanceTo(buf, "rating")
@@ -209,16 +209,16 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	_, err = io.Copy(tmp, buf)
 
 	// Seek back to the last array element.
-	err = r.Seek(193, tmp)
+	err = r.Seek(209, tmp)
 	s.Assert().Nil(err)
-	// Position set to 193
-	s.Assert().Equal(193, r.Pos())
+	// Position set to 209
+	s.Assert().Equal(209, r.Pos())
 
 	// Read last array element's "Name" field again from the temp file.
 	name, err := r.ReadStringField(tmp)
 	s.Assert().Nil(err)
 	s.Assert().Equal("this is from 2022", name)
-	s.Assert().Equal(214, r.Pos())
+	s.Assert().Equal(230, r.Pos())
 }
 
 func (s *ReaderMigrationSuite) TestAdvanceErrors() {
@@ -228,14 +228,14 @@ func (s *ReaderMigrationSuite) TestAdvanceErrors() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(101, r.Pos())
+	s.Assert().Equal(114, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(105, r.Pos())
+	s.Assert().Equal(118, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -244,7 +244,7 @@ func (s *ReaderMigrationSuite) TestAdvanceErrors() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(127, r.Pos())
 
 	// Attempt to advance to field that doesn't exist
 	err = r.AdvanceTo(buf, "nothere")

--- a/rsf.go
+++ b/rsf.go
@@ -102,9 +102,10 @@ const (
 
 // A struct used to record and pass information about `rsf` struct tags
 type tag struct {
-	name     string
-	fixed    int
-	index    string
-	indexSz  int
-	indexVal any
+	name      string
+	fixed     int
+	index     string
+	indexSz   int
+	indexVal  any
+	indexType int
 }

--- a/writer.go
+++ b/writer.go
@@ -8,13 +8,35 @@ import (
 	"math"
 )
 
+// IndexVersion2 is the first recorded index version. It consists of:
+//   - NULL
+//   - backspace
+//   - ASCII character "2".
+var IndexVersion2 = []byte{0x00, 0x08, 0x32}
+
+var (
+	Version1 = 1
+	Version2 = 2
+)
+
 type rsfWriter struct {
-	writer io.Writer
-	pos    int
+	writer  io.Writer
+	version int
+	pos     int
 }
 
 func NewWriter(f io.Writer) Writer {
-	return &rsfWriter{writer: f}
+	return &rsfWriter{
+		writer:  f,
+		version: Version1,
+	}
+}
+
+func NewWriterWithVersion(f io.Writer, version int) Writer {
+	return &rsfWriter{
+		writer:  f,
+		version: version,
+	}
 }
 
 func (f *rsfWriter) WriteSizeField(pos int, val int, r io.Writer) (int, error) {

--- a/writer_complex_test.go
+++ b/writer_complex_test.go
@@ -47,94 +47,571 @@ type FullPackageRecordPyPI struct {
 	Popularity    int64                      `rsf:"popularity"`
 }
 
+var testComplexData = []FullPackageRecordPyPI{
+	{
+		HomePage:      "http://homepage.com",
+		CanonicalName: "numpy",
+		ProjectName:   "Numpy",
+		Classifiers: []Classifier{
+			{
+				Name:   "License",
+				Type:   2,
+				Values: []string{"one", "two", "three"},
+			},
+			{
+				Name: "Usage",
+				Type: 1,
+			},
+		},
+		Author: "an-author",
+		Snapshots: []FullManifestSnapshotPyPI{
+			{
+				CanonicalName: "ignored",
+				ProjectName:   "ignored",
+				Description:   "The description of numpy",
+				Deleted:       false,
+				Snapshot:      "2020-10-11",
+				Version:       "3.0.3",
+				Summary:       "numpy summary",
+				License:       "MIT",
+			}, {
+				CanonicalName: "ignored",
+				ProjectName:   "ignored",
+				Description:   "Older description of numpy",
+				Deleted:       false,
+				Snapshot:      "2020-10-10",
+				Version:       "3.0.2",
+				Summary:       "numpy summary",
+				License:       "MIT",
+			}, {
+				CanonicalName: "ignored",
+				ProjectName:   "ignored",
+				Deleted:       true,
+				Snapshot:      "2020-10-09",
+			},
+		},
+		Popularity: 55,
+	},
+	{
+		HomePage:      "http://django-home.com",
+		CanonicalName: "django",
+		ProjectName:   "Django",
+		Classifiers: []Classifier{
+			{
+				Name:   "License",
+				Type:   2,
+				Values: []string{"one", "two"},
+			},
+			{
+				Name: "Usage",
+				Type: 1,
+			},
+		},
+		Author: "be-an-author",
+		Snapshots: []FullManifestSnapshotPyPI{
+			{
+				CanonicalName: "ignored",
+				ProjectName:   "ignored",
+				Description:   "The description of django",
+				Deleted:       false,
+				Snapshot:      "2020-10-11",
+				Version:       "3.0.3",
+				Summary:       "django summary",
+				License:       "MIT",
+			}, {
+				CanonicalName: "ignored",
+				ProjectName:   "ignored",
+				Deleted:       true,
+				Snapshot:      "2020-10-09",
+			},
+		},
+		Popularity: 55,
+	},
+}
+
+// TestWriteComplexObject tests writing `testComplexData` using the current Version2
+// index format.
 func (s *WriterComplexSuite) TestWriteComplexObject() {
+	buf := &bytes.Buffer{}
+	w := NewWriterWithVersion(buf, Version2)
+
+	var totalSz int
+	for _, obj := range testComplexData {
+		sz, err := w.WriteObject(obj)
+		s.Assert().Nil(err)
+		totalSz += sz
+	}
+	// Object should use 888 bytes.
+	s.Assert().Equal(888, totalSz)
+	s.Assert().Len(buf.Bytes(), 888)
+	// Verify bytes.
+	s.Assert().Equal([]byte{
+		//
+		// Object index header
+		//
+		// Index version 2
+		0x0, 0x8, 0x32,
+		//
+		// Index size
+		0xa, 0x1, 0x0, 0x0,
+		//
+		// Fields Index
+		//
+		// "homepage"
+		0x8, 0x0, 0x0, 0x0,
+		0x68, 0x6f, 0x6d, 0x65, 0x70, 0x61, 0x67, 0x65,
+		// type
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "cname"
+		0x5, 0x0, 0x0, 0x0,
+		0x63, 0x6e, 0x61, 0x6d, 0x65,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "pname"
+		0x5, 0x0, 0x0, 0x0,
+		0x70, 0x6e, 0x61, 0x6d, 0x65,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "classifiers" (array)
+		0xb, 0x0, 0x0, 0x0,
+		0x63, 0x6c, 0x61, 0x73, 0x73, 0x69, 0x66, 0x69, 0x65, 0x72, 0x73,
+		// array type
+		0x4, 0x0, 0x0, 0x0,
+		// not indexed
+		0x0,
+		// array subtype
+		0x19, 0x0, 0x0, 0x0,
+		// 3 subfields
+		0x3, 0x0, 0x0, 0x0,
+		//
+		// "classifiers" - "name"
+		0x4, 0x0, 0x0, 0x0,
+		0x6e, 0x61, 0x6d, 0x65,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "classifiers" - "type" (int)
+		0x4, 0x0, 0x0, 0x0,
+		0x74, 0x79, 0x70, 0x65,
+		0x7, 0x0, 0x0, 0x0,
+		//
+		// "classifiers" - "values" (array)
+		0x6, 0x0, 0x0, 0x0,
+		0x76, 0x61, 0x6c, 0x75, 0x65, 0x73,
+		0x4, 0x0, 0x0, 0x0,
+		// not indexed
+		0x0,
+		// Subtype
+		0x18, 0x0, 0x0, 0x0,
+		// string array has zero subfields
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// "author"
+		0x6, 0x0, 0x0, 0x0,
+		0x61, 0x75, 0x74, 0x68, 0x6f, 0x72,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" (array)
+		0x9, 0x0, 0x0, 0x0,
+		0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x73,
+		// "array" type
+		0x4, 0x0, 0x0, 0x0,
+		// "snapshots" array is indexed
+		0x1,
+		// "snapshots" array index type
+		0x18, 0x0, 0x0, 0x0,
+		// "snapshots" array field size 10
+		0xa, 0x0, 0x0, 0x0,
+		// "snapshots" array field type (struct)
+		0x19, 0x0, 0x0, 0x0,
+		// 5 subfields for snapshots array
+		0x5, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" - "description"
+		0xb, 0x0, 0x0, 0x0,
+		0x64, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" - "deleted" (bool)
+		0x7, 0x0, 0x0, 0x0,
+		0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64,
+		0x3, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" - "version"
+		0x7, 0x0, 0x0, 0x0,
+		0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" - "summary"
+		0x7, 0x0, 0x0, 0x0,
+		0x73, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "snapshots" - "license"
+		0x7, 0x0, 0x0, 0x0,
+		0x6c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65,
+		0x1, 0x0, 0x0, 0x0,
+		//
+		// "popularity" (int)
+		0xa, 0x0, 0x0, 0x0,
+		0x70, 0x6f, 0x70, 0x75, 0x6c, 0x61, 0x72, 0x69, 0x74, 0x79,
+		0x7, 0x0, 0x0, 0x0,
+		//
+		// -- end index --
+		// -- start object --
+		//
+		// Object size
+		0x5c, 0x1, 0x0, 0x0,
+		//
+		// "http://homepage.com"
+		0x13, 0x0, 0x0, 0x0,
+		0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x68, 0x6f, 0x6d,
+		0x65, 0x70, 0x61, 0x67, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+		//
+		// "numpy"
+		0x5, 0x0, 0x0, 0x0,
+		0x6e, 0x75, 0x6d, 0x70, 0x79,
+		//
+		// "Numpy"
+		0x5, 0x0, 0x0, 0x0,
+		0x4e, 0x75, 0x6d, 0x70, 0x79,
+		//
+		// -- start array --
+		//
+		// "classifiers" array size
+		0x57, 0x0, 0x0, 0x0,
+		// array length
+		0x2, 0x0, 0x0, 0x0,
+		// "License"
+		0x7, 0x0, 0x0, 0x0,
+		0x4c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65,
+		// 2
+		0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		// "values" array size
+		0x1f, 0x0, 0x0, 0x0,
+		// array length
+		0x3, 0x0, 0x0, 0x0,
+		// "one"
+		0x3, 0x0, 0x0, 0x0,
+		0x6f, 0x6e, 0x65,
+		// "two"
+		0x3, 0x0, 0x0, 0x0,
+		0x74, 0x77, 0x6f,
+		// "three"
+		0x5, 0x0, 0x0, 0x0,
+		0x74, 0x68, 0x72, 0x65, 0x65,
+		//
+		// "Usage"
+		0x5, 0x0, 0x0, 0x0,
+		0x55, 0x73, 0x61, 0x67, 0x65,
+		// 1
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		// "values" array size
+		0x8, 0x0, 0x0, 0x0,
+		// zero len array
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// -- end array --
+		//
+		// "an-author"
+		0x9, 0x0, 0x0, 0x0,
+		0x61, 0x6e, 0x2d, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72,
+		//
+		// -- start "snapshots" array
+		//
+		// Array size
+		0xc1, 0x0, 0x0, 0x0,
+		// Array length
+		0x3, 0x0, 0x0, 0x0,
+		//
+		// -- Array index --
+		//
+		// "2020-10-11"
+		0x32, 0x30, 0x32, 0x30, 0x2d, 0x31, 0x30, 0x2d, 0x31, 0x31,
+		0x3e, 0x0, 0x0, 0x0,
+		// "2020-10-10"
+		0x32, 0x30, 0x32, 0x30, 0x2d, 0x31, 0x30, 0x2d, 0x31, 0x30,
+		0x40, 0x0, 0x0, 0x0,
+		// "2020-10-09"
+		0x32, 0x30, 0x32, 0x30, 0x2d, 0x31, 0x30, 0x2d, 0x30, 0x39,
+		0x11, 0x0, 0x0, 0x0,
+		//
+		// -- end array index --
+		// -- array data --
+		//
+		// "The description of numpy"
+		0x18, 0x0, 0x0, 0x0,
+		0x54, 0x68, 0x65, 0x20, 0x64, 0x65, 0x73, 0x63, 0x72, 0x69,
+		0x70, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x6e,
+		0x75, 0x6d, 0x70, 0x79,
+		//
+		// false
+		0x0,
+		//
+		// "3.0.3"
+		0x5, 0x0, 0x0, 0x0,
+		0x33, 0x2e, 0x30, 0x2e, 0x33,
+		//
+		// "numpy summary"
+		0xd, 0x0, 0x0, 0x0,
+		0x6e, 0x75, 0x6d, 0x70, 0x79, 0x20, 0x73, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79,
+		//
+		// "MIT"
+		0x3, 0x0, 0x0, 0x0,
+		0x4d, 0x49, 0x54,
+		//
+		// ------
+		//
+		// "Older description of numpy"
+		0x1a, 0x0, 0x0, 0x0,
+		0x4f, 0x6c, 0x64, 0x65, 0x72, 0x20, 0x64, 0x65, 0x73, 0x63,
+		0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6f, 0x66,
+		0x20, 0x6e, 0x75, 0x6d, 0x70, 0x79,
+		// false
+		0x0,
+		// "3.0.2"
+		0x5, 0x0, 0x0, 0x0,
+		0x33, 0x2e, 0x30, 0x2e, 0x32,
+		// "numpy summary"
+		0xd, 0x0, 0x0, 0x0,
+		0x6e, 0x75, 0x6d, 0x70, 0x79, 0x20, 0x73, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79,
+		// "MIT"
+		0x3, 0x0, 0x0, 0x0,
+		0x4d, 0x49, 0x54,
+		//
+		// ------
+		//
+		// no description
+		0x0, 0x0, 0x0, 0x0,
+		// true
+		0x1,
+		// no version
+		0x0, 0x0, 0x0, 0x0,
+		// no summary
+		0x0, 0x0, 0x0, 0x0,
+		// no license
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// -- end array --
+		//
+		// 55 (popularity)
+		0x6e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		//
+		// -- end object --
+		//
+		// Next object size
+		0xf, 0x1, 0x0, 0x0,
+		//
+		// "http://django-home.com"
+		0x16, 0x0, 0x0, 0x0,
+		0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x64, 0x6a, 0x61,
+		0x6e, 0x67, 0x6f, 0x2d, 0x68, 0x6f, 0x6d, 0x65, 0x2e, 0x63,
+		0x6f, 0x6d,
+		//
+		// "django",
+		0x6, 0x0, 0x0, 0x0,
+		0x64, 0x6a, 0x61, 0x6e, 0x67, 0x6f,
+		//
+		// "Django"
+		0x6, 0x0, 0x0, 0x0,
+		0x44, 0x6a, 0x61, 0x6e, 0x67, 0x6f,
+		//
+		// -- start array --
+		//
+		// "classifiers" array size
+		0x4e, 0x0, 0x0, 0x0,
+		// array length
+		0x2, 0x0, 0x0, 0x0,
+		//
+		// "License"
+		0x7, 0x0, 0x0, 0x0,
+		0x4c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65,
+		//
+		// 2
+		0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		//
+		// "values" array size
+		0x16, 0x0, 0x0, 0x0,
+		//
+		// "values" array length
+		0x2, 0x0, 0x0, 0x0,
+		//
+		// "one"
+		0x3, 0x0, 0x0, 0x0,
+		0x6f, 0x6e, 0x65,
+		//
+		// "two"
+		0x3, 0x0, 0x0, 0x0,
+		0x74, 0x77, 0x6f,
+		//
+		// "Usage"
+		0x5, 0x0, 0x0, 0x0,
+		0x55, 0x73, 0x61, 0x67, 0x65,
+		//
+		// 1
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		// "values" array size"
+		0x8, 0x0, 0x0, 0x0,
+		//
+		// zero length array
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// -- end array --
+		//
+		// "be-an-author"
+		0xc, 0x0, 0x0, 0x0,
+		0x62, 0x65, 0x2d, 0x61, 0x6e, 0x2d, 0x61, 0x75, 0x74, 0x68, 0x6f, 0x72,
+		//
+		// -- array start --
+		//
+		// "snapshots" array size
+		0x75, 0x0, 0x0, 0x0,
+		// "snapshots" array length
+		0x2, 0x0, 0x0, 0x0,
+		//
+		// -- Array index --
+		//
+		// "2020-10-11"
+		0x32, 0x30, 0x32, 0x30, 0x2d, 0x31, 0x30, 0x2d, 0x31, 0x31,
+		0x40, 0x0, 0x0, 0x0,
+		// "2020-10-09"
+		0x32, 0x30, 0x32, 0x30, 0x2d, 0x31, 0x30, 0x2d, 0x30, 0x39,
+		0x11, 0x0, 0x0, 0x0,
+		//
+		// -- end array index --
+		// -- array data --
+		//
+		//
+		// "The description of django"
+		0x19, 0x0, 0x0, 0x0,
+		0x54, 0x68, 0x65, 0x20, 0x64, 0x65, 0x73, 0x63, 0x72, 0x69,
+		0x70, 0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x64,
+		0x6a, 0x61, 0x6e, 0x67, 0x6f,
+		//
+		// false
+		0x0,
+		//
+		// "3.0.3
+		0x5, 0x0, 0x0, 0x0,
+		0x33, 0x2e, 0x30, 0x2e, 0x33,
+		//
+		// "django summary"
+		0xe, 0x0, 0x0, 0x0,
+		0x64, 0x6a, 0x61, 0x6e, 0x67, 0x6f, 0x20, 0x73, 0x75, 0x6d,
+		0x6d, 0x61, 0x72, 0x79,
+		//
+		// "MIT"
+		0x3, 0x0, 0x0, 0x0,
+		0x4d, 0x49, 0x54,
+		//
+		// no description
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// true
+		0x1,
+		//
+		// no version
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// no summary
+		0x0, 0x0, 0x0, 0x0,
+		// no license
+		0x0, 0x0, 0x0, 0x0,
+		//
+		// -- end array --
+		//
+		// 55
+		0x6e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+	}, buf.Bytes())
+
+	pbuf := &bytes.Buffer{}
+	err := Print(pbuf, bufio.NewReader(buf))
+	s.Require().Nil(err)
+	s.Require().Equal(`
+-----------------------------------------
+                Object[1]                
+-----------------------------------------
+homepage (string): http://homepage.com
+cname (string): numpy
+pname (string): Numpy
+classifiers (array(2)):
+    -
+    name (string): License
+    type (int): 2
+    values (array(3)):
+        -one
+        -two
+        -three
+    -
+    name (string): Usage
+    type (int): 1
+    values (array(0)):
+author (string): an-author
+snapshots (indexed array(3)):
+    - 2020-10-11
+    description (string): The description of numpy
+    deleted (bool): false
+    version (string): 3.0.3
+    summary (string): numpy summary
+    license (string): MIT
+    - 2020-10-10
+    description (string): Older description of numpy
+    deleted (bool): false
+    version (string): 3.0.2
+    summary (string): numpy summary
+    license (string): MIT
+    - 2020-10-09
+    description (string): 
+    deleted (bool): true
+    version (string): 
+    summary (string): 
+    license (string): 
+popularity (int): 55
+
+-----------------------------------------
+                Object[2]                
+-----------------------------------------
+homepage (string): http://django-home.com
+cname (string): django
+pname (string): Django
+classifiers (array(2)):
+    -
+    name (string): License
+    type (int): 2
+    values (array(2)):
+        -one
+        -two
+    -
+    name (string): Usage
+    type (int): 1
+    values (array(0)):
+author (string): be-an-author
+snapshots (indexed array(2)):
+    - 2020-10-11
+    description (string): The description of django
+    deleted (bool): false
+    version (string): 3.0.3
+    summary (string): django summary
+    license (string): MIT
+    - 2020-10-09
+    description (string): 
+    deleted (bool): true
+    version (string): 
+    summary (string): 
+    license (string): 
+popularity (int): 55
+`, "\n"+pbuf.String())
+}
+
+// TestWriteV1ComplexObject tests writing `testComplexData` using the legacy Version1
+// index format. It also validates that we can still read the Version1 index
+// format with no errors.
+func (s *WriterComplexSuite) TestWriteV1ComplexObject() {
 	buf := &bytes.Buffer{}
 	w := NewWriter(buf)
 
-	a := []FullPackageRecordPyPI{
-		{
-			HomePage:      "http://homepage.com",
-			CanonicalName: "numpy",
-			ProjectName:   "Numpy",
-			Classifiers: []Classifier{
-				{
-					Name:   "License",
-					Type:   2,
-					Values: []string{"one", "two", "three"},
-				},
-				{
-					Name: "Usage",
-					Type: 1,
-				},
-			},
-			Author: "an-author",
-			Snapshots: []FullManifestSnapshotPyPI{
-				{
-					CanonicalName: "ignored",
-					ProjectName:   "ignored",
-					Description:   "The description of numpy",
-					Deleted:       false,
-					Snapshot:      "2020-10-11",
-					Version:       "3.0.3",
-					Summary:       "numpy summary",
-					License:       "MIT",
-				}, {
-					CanonicalName: "ignored",
-					ProjectName:   "ignored",
-					Description:   "Older description of numpy",
-					Deleted:       false,
-					Snapshot:      "2020-10-10",
-					Version:       "3.0.2",
-					Summary:       "numpy summary",
-					License:       "MIT",
-				}, {
-					CanonicalName: "ignored",
-					ProjectName:   "ignored",
-					Deleted:       true,
-					Snapshot:      "2020-10-09",
-				},
-			},
-			Popularity: 55,
-		},
-		{
-			HomePage:      "http://django-home.com",
-			CanonicalName: "django",
-			ProjectName:   "Django",
-			Classifiers: []Classifier{
-				{
-					Name:   "License",
-					Type:   2,
-					Values: []string{"one", "two"},
-				},
-				{
-					Name: "Usage",
-					Type: 1,
-				},
-			},
-			Author: "be-an-author",
-			Snapshots: []FullManifestSnapshotPyPI{
-				{
-					CanonicalName: "ignored",
-					ProjectName:   "ignored",
-					Description:   "The description of django",
-					Deleted:       false,
-					Snapshot:      "2020-10-11",
-					Version:       "3.0.3",
-					Summary:       "django summary",
-					License:       "MIT",
-				}, {
-					CanonicalName: "ignored",
-					ProjectName:   "ignored",
-					Deleted:       true,
-					Snapshot:      "2020-10-09",
-				},
-			},
-			Popularity: 55,
-		},
-	}
-
 	var totalSz int
-	for _, obj := range a {
+	for _, obj := range testComplexData {
 		sz, err := w.WriteObject(obj)
 		s.Assert().Nil(err)
 		totalSz += sz
@@ -502,81 +979,84 @@ func (s *WriterComplexSuite) TestWriteComplexObject() {
 		0x6e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 	}, buf.Bytes())
 
-	pbuf := &bytes.Buffer{}
-	err := Print(pbuf, bufio.NewReader(buf), FullPackageRecordPyPI{})
+	// Now, ensure we can still read the v1 index.
+	r := NewReader()
+	idx, err := r.ReadIndex(buf)
 	s.Require().Nil(err)
-	s.Require().Equal(`
---------------------------------------------------------
-                FullPackageRecordPyPI[1]                
---------------------------------------------------------
-homepage (string): http://homepage.com
-cname (string): numpy
-pname (string): Numpy
-classifiers (array(2)):
-    -
-    name (string): License
-    type (int): 2
-    values (array(3)):
-        -one
-        -two
-        -three
-    -
-    name (string): Usage
-    type (int): 1
-    values (array(0)):
-author (string): an-author
-snapshots (indexed array(3)):
-    - 2020-10-11
-    description (string): The description of numpy
-    deleted (bool): false
-    version (string): 3.0.3
-    summary (string): numpy summary
-    license (string): MIT
-    - 2020-10-10
-    description (string): Older description of numpy
-    deleted (bool): false
-    version (string): 3.0.2
-    summary (string): numpy summary
-    license (string): MIT
-    - 2020-10-09
-    description (string): 
-    deleted (bool): true
-    version (string): 
-    summary (string): 
-    license (string): 
-popularity (int): 55
+	s.Require().Equal(Index{
+		IndexEntry{
+			FieldName: "homepage",
+			FieldType: 1,
+		},
+		IndexEntry{
+			FieldName: "cname",
+			FieldType: 1,
+		},
+		IndexEntry{
+			FieldName: "pname",
+			FieldType: 1,
+		},
+		IndexEntry{
+			FieldName: "classifiers",
+			FieldType: 4,
+			Subfields: Index{
+				IndexEntry{
+					FieldName: "name",
+					FieldType: 1,
+				},
+				IndexEntry{
+					FieldName: "type",
+					FieldType: 7,
+				},
+				IndexEntry{
+					FieldName: "values",
+					FieldType: 4,
+				},
+			},
+		},
+		IndexEntry{
+			FieldName: "author",
+			FieldType: 1,
+		},
+		IndexEntry{
+			FieldName: "snapshots",
+			FieldType: 4,
+			Subfields: Index{
+				IndexEntry{
+					FieldName: "description",
+					FieldType: 1,
+				},
+				IndexEntry{
+					FieldName: "deleted",
+					FieldType: 3,
+				},
+				IndexEntry{
+					FieldName: "version",
+					FieldType: 1,
+				},
+				IndexEntry{
+					FieldName: "summary",
+					FieldType: 1,
+				},
+				IndexEntry{
+					FieldName: "license",
+					FieldType: 1,
+				},
+			},
+		},
+		IndexEntry{
+			FieldName: "popularity",
+			FieldType: 7,
+		},
+	}, idx)
 
---------------------------------------------------------
-                FullPackageRecordPyPI[2]                
---------------------------------------------------------
-homepage (string): http://django-home.com
-cname (string): django
-pname (string): Django
-classifiers (array(2)):
-    -
-    name (string): License
-    type (int): 2
-    values (array(2)):
-        -one
-        -two
-    -
-    name (string): Usage
-    type (int): 1
-    values (array(0)):
-author (string): be-an-author
-snapshots (indexed array(2)):
-    - 2020-10-11
-    description (string): The description of django
-    deleted (bool): false
-    version (string): 3.0.3
-    summary (string): django summary
-    license (string): MIT
-    - 2020-10-09
-    description (string): 
-    deleted (bool): true
-    version (string): 
-    summary (string): 
-    license (string): 
-popularity (int): 55
-`, "\n"+pbuf.String())
+	// Read the object size
+	objectSz, err := r.ReadSizeField(buf)
+	s.Require().Nil(err)
+	s.Require().Equal(348, objectSz)
+
+	// Read the next value
+	homePage, err := r.ReadStringField(buf)
+	s.Require().Nil(err)
+	s.Require().Equal("http://homepage.com", homePage)
 }

--- a/writer_downgrade_test.go
+++ b/writer_downgrade_test.go
@@ -58,10 +58,10 @@ func (s *WriterDowngradeSuite) TestWriteObjectAndDowngrade() {
 		},
 	}
 	buf1 := &bytes.Buffer{}
-	w1 := NewWriter(buf1)
+	w1 := NewWriterWithVersion(buf1, Version2)
 	sz, err := w1.WriteObject(a)
 	s.Assert().Nil(err)
-	s.Assert().Equal(233, sz)
+	s.Assert().Equal(249, sz)
 
 	// Create some "upgraded" objects that include new fields not present in the
 	// legacy structs that follow. The structs maintain the original fields and
@@ -159,10 +159,10 @@ func (s *WriterDowngradeSuite) TestWriteObjectAndDowngrade() {
 		},
 	}
 	buf2 := &bytes.Buffer{}
-	w2 := NewWriter(buf2)
+	w2 := NewWriterWithVersion(buf2, Version2)
 	sz, err = w2.WriteObject(b)
 	s.Assert().Nil(err)
-	s.Assert().Equal(750, sz)
+	s.Assert().Equal(792, sz)
 
 	// Read the legacy struct with the expected set of fields.
 	s.validateRead(buf1)
@@ -173,12 +173,12 @@ func (s *WriterDowngradeSuite) TestWriteObjectAndDowngrade() {
 	s.validateRead(buf2)
 
 	pbuf := &bytes.Buffer{}
-	err = Print(pbuf, bufio.NewReader(bufSave), b)
+	err = Print(pbuf, bufio.NewReader(bufSave))
 	s.Require().Nil(err)
 	s.Require().Equal(`
------------------------------------
-                [1]                
------------------------------------
+-----------------------------------------
+                Object[1]                
+-----------------------------------------
 location (string): Albuquerque
 company (string): posit
 products (indexed array(2)):

--- a/writer_upgrade_test.go
+++ b/writer_upgrade_test.go
@@ -57,10 +57,10 @@ func (s *WriterUpgradeSuite) TestWriteObjectAndUpgrade() {
 		},
 	}
 	buf1 := &bytes.Buffer{}
-	w1 := NewWriter(buf1)
+	w1 := NewWriterWithVersion(buf1, Version2)
 	sz, err := w1.WriteObject(a)
 	s.Assert().Nil(err)
-	s.Assert().Equal(233, sz)
+	s.Assert().Equal(249, sz)
 
 	// Create some "upgraded" objects that include new fields not present in the
 	// legacy structs that follow. The structs maintain the original fields and
@@ -143,10 +143,10 @@ func (s *WriterUpgradeSuite) TestWriteObjectAndUpgrade() {
 		},
 	}
 	buf2 := &bytes.Buffer{}
-	w2 := NewWriter(buf2)
+	w2 := NewWriterWithVersion(buf2, Version2)
 	sz, err = w2.WriteObject(b)
 	s.Assert().Nil(err)
-	s.Assert().Equal(627, sz)
+	s.Assert().Equal(656, sz)
 
 	// Read the legacy struct with the expected set of fields.
 	s.validateRead(buf1)


### PR DESCRIPTION
* Adds versioning to the RSF index
  * Legacy behavior if `Version1` is used.
  * New information about indexed arrays is stored in the index when `Version2` is used.
* `rsf.Print` method no longer requires passing a type.
* Adds an `rsfprint` binary that can be built to print the contents of a `Version2` RSF file.
* Adds a `Makefile` with a `build` target for the `rsfprint` binary, and adds the build step to CI.

With these changes, we still default to writing the older `Version1` format since it's required by PPM's PyPI support.

My current plan is to continue using the `Version1` format for PyPI so we don't need to generate two PyPI manifests concurrently. We can start using `Version2` for CRAN and Bioconductor from the start, though, to give us the benefits of the better indexing and pretty-printing during development.