### PR TITLE
V2 Index Reading Fixes

### DIFF
--- a/reader_advance_test.go
+++ b/reader_advance_test.go
@@ -25,14 +25,14 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(117, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(118, r.Pos())
+	s.Assert().Equal(121, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -41,7 +41,7 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(127, r.Pos())
+	s.Assert().Equal(130, r.Pos())
 
 	// Skip the ready field and advance to "list"
 	// Array should be 100 bytes in size
@@ -52,17 +52,17 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	s.Assert().Nil(err)
 	s.Assert().Equal(100, arraySz)
 	// Position increased by 4
-	s.Assert().Equal(132, r.Pos())
+	s.Assert().Equal(135, r.Pos())
 	// Get expect array end position
 	arrayEndPos := arrayPos + arraySz
-	s.Assert().Equal(228, arrayEndPos)
+	s.Assert().Equal(231, arrayEndPos)
 
 	// Array should be 3 elements in length
 	arrayLen, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(3, arrayLen)
 	// Position increased by 4
-	s.Assert().Equal(136, r.Pos())
+	s.Assert().Equal(139, r.Pos())
 
 	// Array index. Read all three index entries
 	// Entry 1
@@ -92,7 +92,7 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// a 10-byte fixed-length string and a 4-byte size field.
 	// 3*14=42
 	// 136+42=178
-	s.Assert().Equal(178, r.Pos())
+	s.Assert().Equal(181, r.Pos())
 
 	// Get the first array element's "Name" field
 	err = r.AdvanceTo(buf, "list", "name")
@@ -103,7 +103,7 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// Position increased by 4+9. String size uses 4 bytes and
 	// string value uses 9 bytes.
 	// 178+13=183
-	s.Assert().Equal(191, r.Pos())
+	s.Assert().Equal(194, r.Pos())
 
 	// Skip the "Verified" field and advance to second array element's "Name" field
 	err = r.AdvanceToNextElement(buf)
@@ -117,7 +117,7 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	// string value uses 9 bytes. Also, the skipped field "verified"
 	// uses 1 byte
 	// 191+13+1=205
-	s.Assert().Equal(205, r.Pos())
+	s.Assert().Equal(208, r.Pos())
 
 	// Read the second array element's "Verified" field
 	err = r.AdvanceTo(buf, "list", "verified")
@@ -125,19 +125,19 @@ func (s *ReaderMigrationSuite) TestAdvanceFields() {
 	verified, err := r.ReadBoolField(buf)
 	s.Assert().Nil(err)
 	s.Assert().True(verified)
-	s.Assert().Equal(206, r.Pos())
+	s.Assert().Equal(209, r.Pos())
 
 	// Skip the last array element's "Name" field and advance to "Verified".
 	// This tests skipping an array sub-element.
 	err = r.AdvanceToNextElement(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(206, r.Pos())
+	s.Assert().Equal(209, r.Pos())
 	err = r.AdvanceTo(buf, "list", "verified")
 	s.Assert().Nil(err)
 	// Last name field (skipped) read "this is from 2022"
 	// 17 bytes + 4 bytes (size) = 21
 	// 206 + 21 = 227
-	s.Assert().Equal(227, r.Pos())
+	s.Assert().Equal(230, r.Pos())
 	verified, err = r.ReadBoolField(buf)
 	s.Assert().Nil(err)
 	s.Assert().True(verified)
@@ -163,14 +163,14 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(117, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(118, r.Pos())
+	s.Assert().Equal(121, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -179,7 +179,7 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(127, r.Pos())
+	s.Assert().Equal(130, r.Pos())
 
 	// Skip the "ready" field and the "list" array and advance
 	// to "age". This tests skipping both a regular field and an entire array.
@@ -188,7 +188,7 @@ func (s *ReaderMigrationSuite) TestAdvanceArray() {
 	age, err := r.ReadIntField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(int64(55), age)
-	s.Assert().Equal(238, r.Pos())
+	s.Assert().Equal(241, r.Pos())
 
 	// Read the "rating" field.
 	err = r.AdvanceTo(buf, "rating")
@@ -228,14 +228,14 @@ func (s *ReaderMigrationSuite) TestAdvanceErrors() {
 	// Read the index
 	_, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(117, r.Pos())
 
 	// Record should be 132 bytes in length
 	recordSz, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(118, r.Pos())
+	s.Assert().Equal(121, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -244,7 +244,7 @@ func (s *ReaderMigrationSuite) TestAdvanceErrors() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(127, r.Pos())
+	s.Assert().Equal(130, r.Pos())
 
 	// Attempt to advance to field that doesn't exist
 	err = r.AdvanceTo(buf, "nothere")

--- a/reader_test.go
+++ b/reader_test.go
@@ -87,7 +87,7 @@ func (s *ReaderSuite) TestRead() {
 	// Read the index
 	index, err := r.ReadIndex(buf)
 	s.Assert().Nil(err)
-	s.Assert().Equal(114, r.Pos())
+	s.Assert().Equal(117, r.Pos())
 
 	// Check the index
 	s.Assert().Equal(Index{
@@ -142,7 +142,7 @@ func (s *ReaderSuite) TestRead() {
 	s.Assert().Nil(err)
 	s.Assert().Equal(132, recordSz)
 	// Position increased by 4 (size field is 4 bytes)
-	s.Assert().Equal(118, r.Pos())
+	s.Assert().Equal(121, r.Pos())
 
 	// Company
 	err = r.AdvanceTo(buf, "company")
@@ -151,7 +151,7 @@ func (s *ReaderSuite) TestRead() {
 	s.Assert().Nil(err)
 	s.Assert().Equal("posit", company)
 	// Position increased by 9. Size field is 4 bytes + data is 5 bytes.
-	s.Assert().Equal(127, r.Pos())
+	s.Assert().Equal(130, r.Pos())
 
 	// Ready
 	err = r.AdvanceTo(buf, "ready")
@@ -160,7 +160,7 @@ func (s *ReaderSuite) TestRead() {
 	s.Assert().Nil(err)
 	s.Assert().True(ready)
 	// Position increased by 1
-	s.Assert().Equal(128, r.Pos())
+	s.Assert().Equal(131, r.Pos())
 
 	// Array should be 100 bytes in size
 	err = r.AdvanceTo(buf, "list")
@@ -169,14 +169,14 @@ func (s *ReaderSuite) TestRead() {
 	s.Assert().Nil(err)
 	s.Assert().Equal(100, arraySz)
 	// Position increased by 4
-	s.Assert().Equal(132, r.Pos())
+	s.Assert().Equal(135, r.Pos())
 
 	// Array should be 3 elements in length
 	arrayLen, err := r.ReadSizeField(buf)
 	s.Assert().Nil(err)
 	s.Assert().Equal(3, arrayLen)
 	// Position increased by 4
-	s.Assert().Equal(136, r.Pos())
+	s.Assert().Equal(139, r.Pos())
 
 	// Array index. Read all three index entries
 	// Entry 1
@@ -206,13 +206,13 @@ func (s *ReaderSuite) TestRead() {
 	// a 10-byte fixed-length string and a 4-byte size field.
 	// 3*14=42
 	// 136+42=170
-	s.Assert().Equal(178, r.Pos())
+	s.Assert().Equal(181, r.Pos())
 
 	// Discard 28 bytes (14+14) to move to the last array element.
 	err = r.Discard(28, buf)
 	s.Assert().Nil(err)
 	// Position increased by 28 to 178+28=206.
-	s.Assert().Equal(206, r.Pos())
+	s.Assert().Equal(209, r.Pos())
 
 	// Read last array element's "Name" field.
 	err = r.AdvanceTo(buf, "list", "name")
@@ -223,7 +223,7 @@ func (s *ReaderSuite) TestRead() {
 	// Position increased by 4+17. String size uses 4 bytes and
 	// string value uses 17 bytes.
 	// 206+21=227
-	s.Assert().Equal(227, r.Pos())
+	s.Assert().Equal(230, r.Pos())
 
 	// Read last array element's "Verified" field.
 	err = r.AdvanceTo(buf, "list", "verified")
@@ -232,7 +232,7 @@ func (s *ReaderSuite) TestRead() {
 	s.Assert().Nil(err)
 	s.Assert().True(verified)
 	// Position increased by 1.
-	s.Assert().Equal(228, r.Pos())
+	s.Assert().Equal(231, r.Pos())
 
 	// Read age field
 	err = r.AdvanceTo(buf, "age")


### PR DESCRIPTION
There were some uncaught issues with reading the V2 index. We were not recording the reader position correctly, but the error wasn't caught by the unit tests. This fixes these issues to get the V2 CRAN manifest working for PPM.