### PR TITLE
Add GetIndex accessor for concurrent record parsing

### DIFF
--- a/reader_index.go
+++ b/reader_index.go
@@ -29,6 +29,14 @@ func (f *rsfReader) SetIndex(newIndex Index) {
 	f.index = newIndex
 }
 
+// GetIndex returns the schema index previously read or set. The returned index
+// is read-only and may be shared across readers — for example to give
+// per-goroutine readers the schema when parsing disjoint record ranges
+// concurrently. It is not part of the Reader interface; callers type-assert.
+func (f *rsfReader) GetIndex() Index {
+	return f.index
+}
+
 func (f *rsfReader) ReadIndex(r io.Reader) (Index, error) {
 	var err error
 


### PR DESCRIPTION
## Description

Adds a `GetIndex()` accessor to the concrete reader that returns the schema index previously read (via `ReadIndex`) or set (via `SetIndex`).

This enables a consumer to parse **disjoint record ranges concurrently**: a worker goroutine can be given the schema once (shared, read-only) instead of re-reading the index, then parse its own byte range over an independent reader. Posit Package Manager uses this to decode CRAN/Bioconductor package records in parallel during graph construction.

It is a method on the concrete `*rsfReader`, **not** part of the `Reader` interface, so callers type-assert and existing implementations/mocks are unaffected.

> Stacked on #30 (buffer reuse). Review/merge that first; this branch targets it.

## Testing

- All existing package tests pass (`go test ./...`).
- Exercised by the downstream consumer (PPM): per-worker readers built with `NewReader()` + `SetIndex(reader.GetIndex())` parse record ranges concurrently and produce byte-identical output, verified under `-race` against PPM's reverse-dependency golden checksums and its all-corpus control-parser differential test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
